### PR TITLE
Add Log system to log properly.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,6 +24,7 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 // START: FlutterFire Configuration
 apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 // END: FlutterFire Configuration
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.0'
         // START: FlutterFire Configuration
         classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
         // END: FlutterFire Configuration
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,12 +10,19 @@ PODS:
     - FirebaseAuth (~> 8.15.0)
   - Firebase/CoreOnly (8.15.0):
     - FirebaseCore (= 8.15.0)
+  - Firebase/Crashlytics (8.15.0):
+    - Firebase/CoreOnly
+    - FirebaseCrashlytics (~> 8.15.0)
   - firebase_auth (3.3.18):
     - Firebase/Auth (= 8.15.0)
     - firebase_core
     - Flutter
   - firebase_core (1.17.0):
     - Firebase/CoreOnly (= 8.15.0)
+    - Flutter
+  - firebase_crashlytics (2.8.0):
+    - Firebase/Crashlytics (= 8.15.0)
+    - firebase_core
     - Flutter
   - FirebaseAuth (8.15.0):
     - FirebaseCore (~> 8.0)
@@ -31,6 +38,18 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
+  - FirebaseCrashlytics (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (~> 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - FirebaseInstallations (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
+    - PromisesObjC (< 3.0, >= 1.2)
   - Flutter (1.0.0)
   - google_sign_in_ios (0.0.1):
     - Flutter
@@ -59,6 +78,8 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.7.0)"
   - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (7.7.0):
+    - GoogleUtilities/Logger
   - GTMAppAuth (1.3.0):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
@@ -77,6 +98,7 @@ PODS:
 DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
@@ -89,6 +111,8 @@ SPEC REPOS:
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCrashlytics
+    - FirebaseInstallations
     - GoogleDataTransport
     - GoogleSignIn
     - GoogleUtilities
@@ -102,6 +126,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_crashlytics:
+    :path: ".symlinks/plugins/firebase_crashlytics/ios"
   Flutter:
     :path: Flutter
   google_sign_in_ios:
@@ -116,9 +142,12 @@ SPEC CHECKSUMS:
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
   firebase_auth: ace975b530600827bd901a9a18584f7cdaf6d160
   firebase_core: aa1b92020533f5c23955e388c347c58fd64f8627
+  firebase_crashlytics: d42b108fa870b889f4c4ea22094647f2aca5f765
   FirebaseAuth: 3e73bf8abf4fbb40f8b421f361f4cc48ee57388c
   FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseCrashlytics: feb07e4e9187be3c23c6a846cce4824e5ce2dd0b
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   google_sign_in_ios: ed71c0dbddfba8b1ea9aa210dbda695f46bf51bd
   GoogleDataTransport: f6eab2486453329104995371bc08d4cafbe3da1f

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				25283014BC4079C158860073 /* [CP] Embed Pods Frameworks */,
 				E1971E0F797B87D0644E7491 /* [CP] Copy Pods Resources */,
+				4A581C29BED9F8940C69ED74 /* [firebase_crashlytics] Crashlytics Upload Symbols */,
 			);
 			buildRules = (
 			);
@@ -250,6 +251,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		4A581C29BED9F8940C69ED74 /* [firebase_crashlytics] Crashlytics Upload Symbols */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}\"",
+				"\"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\"",
+			);
+			name = "[firebase_crashlytics] Crashlytics Upload Symbols";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" --flutter-project \"$PROJECT_DIR/firebase_app_id_file.json\" ";
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/authentication_repository/lib/src/authentication_repository.dart
+++ b/packages/authentication_repository/lib/src/authentication_repository.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:log/log.dart';
 import 'package:meta/meta.dart';
 
 /// {@template sign_up_with_email_and_password_failure}
@@ -161,6 +162,8 @@ class AuthenticationRepository {
         _firebaseAuth = firebaseAuth ?? firebase_auth.FirebaseAuth.instance,
         _googleSignIn = googleSignIn ?? GoogleSignIn.standard();
 
+  final TAG = 'Auth';
+
   final CacheClient _cache;
   final firebase_auth.FirebaseAuth _firebaseAuth;
   final GoogleSignIn _googleSignIn;
@@ -208,6 +211,8 @@ class AuthenticationRepository {
     } catch (_) {
       throw const SignUpWithEmailAndPasswordFailure();
     }
+
+    Log.i('$TAG: Successfully signed up.');
   }
 
   /// Starts the Sign In with Google Flow.
@@ -256,6 +261,8 @@ class AuthenticationRepository {
     } catch (_) {
       throw const LogInWithEmailAndPasswordFailure();
     }
+
+    Log.i('$TAG: Successfully Logged in.');
   }
 
   /// Signs out the current user which will emit
@@ -271,6 +278,8 @@ class AuthenticationRepository {
     } catch (_) {
       throw LogOutFailure();
     }
+
+    Log.i('$TAG: Successfully Logged out.');
   }
 }
 

--- a/packages/authentication_repository/pubspec.lock
+++ b/packages/authentication_repository/pubspec.lock
@@ -155,11 +155,32 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  firebase_crashlytics:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.8.0"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.6"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_loggy:
+    dependency: transitive
+    description:
+      name: flutter_loggy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -254,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.4"
+  log:
+    dependency: "direct main"
+    description:
+      path: "../log"
+      relative: true
+    source: path
+    version: "0.0.1"
   logging:
     dependency: transitive
     description:
@@ -261,6 +289,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  loggy:
+    dependency: transitive
+    description:
+      name: loggy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1+1"
   matcher:
     dependency: transitive
     description:
@@ -345,6 +380,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.3"
   shelf:
     dependency: transitive
     description:

--- a/packages/authentication_repository/pubspec.yaml
+++ b/packages/authentication_repository/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   cache:
     path: ../cache
+  log:
+    path: ../log
   equatable: ^2.0.3
   firebase_auth: ^3.3.18
   firebase_core: ^1.17.0

--- a/packages/log/.gitignore
+++ b/packages/log/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/log/.metadata
+++ b/packages/log/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: ee4e09cce01d6f2d7f4baebd247fde02e5008851
+  channel: stable
+
+project_type: package

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/log/LICENSE
+++ b/packages/log/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/log/analysis_options.yaml
+++ b/packages/log/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/log/lib/log.dart
+++ b/packages/log/lib/log.dart
@@ -1,0 +1,146 @@
+// ignore_for_file: avoid_print
+
+library log;
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_loggy/flutter_loggy.dart';
+import 'package:loggy/loggy.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+class Log {
+  static void init({bool firebaseEnable = true, bool verbose = false}) {
+    Loggy.initLoggy(
+      logPrinter: _MultiPrinter(
+        printers: firebaseEnable
+            ? [
+                _CustomPrinter(),
+                _FirebasePrinter(),
+                const PrettyDeveloperPrinter()
+              ]
+            : [_CustomPrinter(), const PrettyDeveloperPrinter()],
+      ),
+      logOptions: LogOptions(
+        kDebugMode ? (verbose ? LogLevel.all : LogLevel.debug) : LogLevel.info,
+        stackTraceLevel: LogLevel.off,
+      ),
+    );
+  }
+
+  static d(dynamic message, [Object? error, StackTrace? stackTrace]) =>
+      _log(message, LogLevel.debug, error, stackTrace);
+  static e(dynamic message, [Object? error, StackTrace? stackTrace]) =>
+      _log(message, LogLevel.error, error, stackTrace);
+  static i(dynamic message, [Object? error, StackTrace? stackTrace]) =>
+      _log(message, LogLevel.info, error, stackTrace);
+  static w(dynamic message, [Object? error, StackTrace? stackTrace]) =>
+      _log(message, LogLevel.warning, error, stackTrace);
+
+  static _log(dynamic message, LogLevel level,
+      [Object? error, StackTrace? stackTrace]) {
+    var prefix = "";
+
+    if (true) {
+      var debug = Trace.current();
+      var member = Trace.current().frames[2].member!.split(".");
+
+      // if there are no corresponding class, then class name will be ""
+      var className = member.length == 2 ? member[1] : "";
+      var methodName = member[0];
+      prefix = "$className/$methodName: ";
+    }
+
+    switch (level) {
+      case LogLevel.debug:
+        logDebug("$prefix$message", error, stackTrace);
+        break;
+      case LogLevel.error:
+        logError("$prefix$message", error, stackTrace);
+        break;
+      case LogLevel.info:
+        logInfo("$prefix$message", error, stackTrace);
+        break;
+      case LogLevel.warning:
+        logWarning("$prefix$message", error, stackTrace);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+String _logFormat(LogRecord record) {
+  const levelPrefixes = {
+    LogLevel.debug: "[D]",
+    LogLevel.info: "[I]",
+    LogLevel.warning: "[W]",
+    LogLevel.error: "[E]",
+  };
+
+  final time = record.time.toIso8601String().split('T')[1];
+  final prefix = levelPrefixes[record.level] ?? "N";
+
+  return "$time: $prefix ${record.message}";
+}
+
+class _CustomPrinter extends LoggyPrinter {
+  static final _levelColors = {
+    LogLevel.debug:
+        AnsiColor(foregroundColor: AnsiColor.grey(0.5), italic: true),
+    LogLevel.info: AnsiColor(foregroundColor: 35),
+    LogLevel.warning: AnsiColor(foregroundColor: 214),
+    LogLevel.error: AnsiColor(foregroundColor: 196),
+  };
+
+  _CustomPrinter() : super();
+
+  @override
+  void onLog(LogRecord record) {
+    final color = _levelColor(record.level) ?? AnsiColor();
+
+    print(color(_logFormat(record)));
+
+    if (record.error != null) {
+      print(record.error);
+    }
+
+    if (record.stackTrace != null) {
+      print(record.stackTrace);
+    }
+  }
+
+  AnsiColor? _levelColor(LogLevel level) {
+    return _levelColors[level];
+  }
+}
+
+class _FirebasePrinter extends LoggyPrinter {
+  _FirebasePrinter() : super();
+
+  @override
+  void onLog(LogRecord record) {
+    FirebaseCrashlytics.instance.log(_logFormat(record));
+    if (record.error != null) {
+      FirebaseCrashlytics.instance.log(record.error.toString());
+    }
+
+    if (record.stackTrace != null) {
+      FirebaseCrashlytics.instance.log(record.stackTrace.toString());
+    }
+  }
+}
+
+class _MultiPrinter extends LoggyPrinter {
+  final List<LoggyPrinter> printers;
+
+  _MultiPrinter({
+    required this.printers,
+  });
+
+  @override
+  void onLog(LogRecord record) {
+    for (var printer in printers) {
+      printer.onLog(record);
+    }
+  }
+}

--- a/packages/log/pubspec.yaml
+++ b/packages/log/pubspec.yaml
@@ -1,0 +1,23 @@
+name: log
+description: A new Flutter package project.
+version: 0.0.1
+homepage:
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  firebase_crashlytics: ^2.8.0
+  flutter:
+    sdk: flutter
+  loggy: ^2.0.1+1
+  flutter_loggy: any
+
+  stack_trace: ^1.10.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+flutter:

--- a/packages/log/test/log_test.dart
+++ b/packages/log/test/log_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:log/log.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+void main() {
+  test('Test Logging', () {
+    Log.init(firebaseEnable: false);
+
+    Log.d("Debug Test");
+    Log.e("Error Test");
+    Log.e("Error test with stack trace", Trace.current());
+    Log.e("Error test with error and stacktrace", Exception("test exception"),
+        Trace.current());
+    Log.e("Error test with only exception", Exception("test exception"));
+    Log.i("Info Test");
+    Log.w("Warning test");
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,6 +309,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.8.0"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.6"
   fixnum:
     dependency: transitive
     description:
@@ -345,6 +359,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_loggy:
+    dependency: transitive
+    description:
+      name: flutter_loggy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -512,6 +533,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  log:
+    dependency: "direct main"
+    description:
+      path: "packages/log"
+      relative: true
+    source: path
+    version: "0.0.1"
   logging:
     dependency: transitive
     description:
@@ -519,6 +547,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  loggy:
+    dependency: "direct main"
+    description:
+      name: loggy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1+1"
   matcher:
     dependency: transitive
     description:
@@ -694,6 +729,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.3"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,18 +15,27 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  cupertino_icons: ^1.0.2
-  flutter_bloc: ^8.0.1
-  json_serializable: ^6.1.6
-  extended_image: ^6.0.2+1
-  firebase_core: ^1.17.0
+  # Internal Packages for ming
   authentication_repository:
     path: packages/authentication_repository
   signin_form:
     path: packages/signin_form
+  log:
+    path: packages/log
+
+  # For pretty & generalized logging
+  loggy: ^2.0.1+1
+
+  # Bloc pattern support
+  flutter_bloc: ^8.0.1
+  cupertino_icons: ^1.0.2
+  json_serializable: ^6.1.6
+  extended_image: ^6.0.2+1
+  firebase_core: ^1.17.0
   formz: ^0.4.0
   google_fonts: ^2.3.2
   font_awesome_flutter: ^9.1.0
+  firebase_crashlytics: ^2.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Loggy(https://pub.dev/packages/loggy) library로 logging system을 구성하였고, Firebase Crashlytics를 enable 해놓았습니다.

현재 web에서는 firebase crashlytics를 support하지 않아서 그 때에는 단순 print로 처리한 상황입니다.

사용법은 간단한데, Log.d("logg"); 처럼 사용하면 됩니다. Test code에 간단한 예제가 있습니다.

Signed-off-by: Hyukjoong Kim <wangmir@gmail.com>