### PR TITLE
Auth Bloc를 분리해서 Auth bloc 기반으로 login auth를 진행하도록 변경.

### DIFF
--- a/lib/auth/bloc/auth_bloc.dart
+++ b/lib/auth/bloc/auth_bloc.dart
@@ -1,0 +1,50 @@
+import 'package:authentication_repository/authentication_repository.dart';
+import 'package:bloc/bloc.dart';
+import 'package:log/log.dart';
+import 'package:meta/meta.dart';
+
+part 'auth_event.dart';
+part 'auth_state.dart';
+
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  final AuthenticationRepository _repository;
+  bool _isInitialized = false;
+
+  AuthBloc({required AuthenticationRepository repository})
+      : _repository = repository,
+        super(AuthInitial()) {
+    on<AuthEvent>(((event, emit) async {
+      if (event is StartListenAuthStatus) {
+        await _onStartListenAuthStatus(event, emit);
+      } else if (event is LogOut) {
+        await _onLogOut(event, emit);
+      }
+    }));
+
+    // 자동로그인을 할 경우 logout 필요없이 바로 auth 진행하면 됨.
+    // 현재의 경우 session이 계속 유지되기 때문에 logout을 명시 해놓음.
+    // todo: 대부분 앱들이 자동 로그인을 default로 제공하는 것 같으니 그냥 유지해도 될 거 같다.
+    repository.logOut().then((value) => add(StartListenAuthStatus()));
+  }
+
+  Future<void> _onStartListenAuthStatus(
+      AuthEvent event, Emitter<AuthState> emit) async {
+    Log.d("start");
+
+    if (_isInitialized) return;
+
+    await emit.forEach(_repository.user, onData: (AuthInfo user) {
+      if (user.isNotEmpty) {
+        return Authenticated(user);
+      }
+      return UnAuthenticated();
+    });
+
+    _isInitialized = true;
+  }
+
+  Future<void> _onLogOut(AuthEvent event, Emitter<AuthState> emit) async {
+    Log.d("start");
+    await _repository.logOut();
+  }
+}

--- a/lib/auth/bloc/auth_event.dart
+++ b/lib/auth/bloc/auth_event.dart
@@ -1,0 +1,10 @@
+part of 'auth_bloc.dart';
+
+@immutable
+abstract class AuthEvent {}
+
+class StartListenAuthStatus extends AuthEvent {}
+
+class LogOut extends AuthEvent {}
+
+// todo: reauth, change password

--- a/lib/auth/bloc/auth_state.dart
+++ b/lib/auth/bloc/auth_state.dart
@@ -1,0 +1,16 @@
+part of 'auth_bloc.dart';
+
+@immutable
+abstract class AuthState {}
+
+class AuthInitial extends AuthState {}
+
+class Authenticated extends AuthState {
+  final AuthInfo info;
+
+  Authenticated(this.info) {
+    Log.d("Authenticated");
+  }
+}
+
+class UnAuthenticated extends AuthState {}

--- a/lib/di/di.dart
+++ b/lib/di/di.dart
@@ -1,5 +1,6 @@
 import 'package:authentication_repository/authentication_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ming/auth/bloc/auth_bloc.dart';
 
 import '../feed/feed.dart';
 import '../login/login.dart';
@@ -17,6 +18,10 @@ List<BlocProvider> blocProviders = [
   BlocProvider<LoginCubit>(
     create: (context) => LoginCubit(context.read<AuthenticationRepository>()),
   ),
+  BlocProvider<AuthBloc>(
+    create: (context) =>
+        AuthBloc(repository: context.read<AuthenticationRepository>()),
+  )
 ];
 
 List<RepositoryProvider> repositoryProviers = [

--- a/lib/login/view/login_form.dart
+++ b/lib/login/view/login_form.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:formz/formz.dart';
 import 'package:go_router/go_router.dart';
 
@@ -31,8 +30,6 @@ class LoginForm extends StatelessWidget {
                 content: Text(S.of(context).loginSuccessMessage),
               ),
             );
-
-          GoRouter.of(context).go('/home');
         }
       },
       child: Align(
@@ -52,8 +49,6 @@ class LoginForm extends StatelessWidget {
               const SizedBox(height: 8),
               _LoginButton(),
               const SizedBox(height: 8),
-              _GoogleLoginButton(),
-              const SizedBox(height: 4),
               _SignUpButton(),
             ],
           ),
@@ -128,28 +123,6 @@ class _LoginButton extends StatelessWidget {
                 child: const Text('LOGIN'),
               );
       },
-    );
-  }
-}
-
-class _GoogleLoginButton extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ElevatedButton.icon(
-      key: const Key('loginForm_googleLogin_raisedButton'),
-      label: const Text(
-        'SIGN IN WITH GOOGLE',
-        style: TextStyle(color: Colors.white),
-      ),
-      style: ElevatedButton.styleFrom(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(30),
-        ),
-        primary: theme.colorScheme.secondary,
-      ),
-      icon: const Icon(FontAwesomeIcons.google, color: Colors.white),
-      onPressed: () => context.read<LoginCubit>().logInWithGoogle(),
     );
   }
 }

--- a/lib/login/view/login_page.dart
+++ b/lib/login/view/login_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ming/auth/bloc/auth_bloc.dart';
 
 import 'login_form.dart';
 
@@ -9,11 +12,18 @@ class LoginPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
-      body: const Padding(
-        padding: EdgeInsets.all(8),
-        child: LoginForm(),
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is Authenticated) {
+          GoRouter.of(context).go("/home");
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Login')),
+        body: const Padding(
+          padding: EdgeInsets.all(8),
+          child: LoginForm(),
+        ),
       ),
     );
   }

--- a/packages/authentication_repository/lib/src/authentication_repository.dart
+++ b/packages/authentication_repository/lib/src/authentication_repository.dart
@@ -146,6 +146,9 @@ class LogInWithGoogleFailure implements Exception {
   final String message;
 }
 
+/// When auth function try to handle auth functinality before login.
+class UserIsNotLoggedInFailure implements Exception {}
+
 /// Thrown during the logout process if a failure occurs.
 class LogOutFailure implements Exception {}
 
@@ -162,8 +165,6 @@ class AuthenticationRepository {
         _firebaseAuth = firebaseAuth ?? firebase_auth.FirebaseAuth.instance,
         _googleSignIn = googleSignIn ?? GoogleSignIn.standard();
 
-  final TAG = 'Auth';
-
   final CacheClient _cache;
   final firebase_auth.FirebaseAuth _firebaseAuth;
   final GoogleSignIn _googleSignIn;
@@ -179,22 +180,31 @@ class AuthenticationRepository {
   @visibleForTesting
   static const userCacheKey = '__user_cache_key__';
 
-  /// Stream of [User] which will emit the current user when
+  /// Stream of [AuthInfo] which will emit the current user when
   /// the authentication state changes.
   ///
-  /// Emits [User.empty] if the user is not authenticated.
-  Stream<User> get user {
+  /// Emits [AuthInfo.empty] if the user is not authenticated.
+  Stream<AuthInfo> get user {
     return _firebaseAuth.authStateChanges().map((firebaseUser) {
-      final user = firebaseUser == null ? User.empty : firebaseUser.toUser;
+      final user =
+          firebaseUser == null ? AuthInfo.empty : firebaseUser.toAuthInfo;
       _cache.write(key: userCacheKey, value: user);
       return user;
     });
   }
 
   /// Returns the current cached user.
-  /// Defaults to [User.empty] if there is no cached user.
-  User get currentUser {
-    return _cache.read<User>(key: userCacheKey) ?? User.empty;
+  /// Defaults to [AuthInfo.empty] if there is no cached user.
+  AuthInfo get currentUser {
+    return _cache.read<AuthInfo>(key: userCacheKey) ?? AuthInfo.empty;
+  }
+
+  /// get id token for the user, if token is expired, then refresh it.
+  /// Throws a [UserIsNotLoggedInFailure] if user is not logged in before.
+  Future<String> get idToken async {
+    if (_firebaseAuth.currentUser == null) throw UserIsNotLoggedInFailure();
+
+    return _firebaseAuth.currentUser!.getIdToken();
   }
 
   /// Creates a new user with the provided [email] and [password].
@@ -212,7 +222,7 @@ class AuthenticationRepository {
       throw const SignUpWithEmailAndPasswordFailure();
     }
 
-    Log.i('$TAG: Successfully signed up.');
+    Log.i('Successfully signed up.');
   }
 
   /// Starts the Sign In with Google Flow.
@@ -262,11 +272,11 @@ class AuthenticationRepository {
       throw const LogInWithEmailAndPasswordFailure();
     }
 
-    Log.i('$TAG: Successfully Logged in.');
+    Log.i('Successfully Logged in.');
   }
 
   /// Signs out the current user which will emit
-  /// [User.empty] from the [user] Stream.
+  /// [AuthInfo.empty] from the [user] Stream.
   ///
   /// Throws a [LogOutFailure] if an exception occurs.
   Future<void> logOut() async {
@@ -279,12 +289,12 @@ class AuthenticationRepository {
       throw LogOutFailure();
     }
 
-    Log.i('$TAG: Successfully Logged out.');
+    Log.i('Successfully Logged out.');
   }
 }
 
 extension on firebase_auth.User {
-  User get toUser {
-    return User(id: uid, email: email, name: displayName, photo: photoURL);
+  AuthInfo get toAuthInfo {
+    return AuthInfo(id: uid, email: email, name: displayName, photo: photoURL);
   }
 }

--- a/packages/authentication_repository/lib/src/models/user.dart
+++ b/packages/authentication_repository/lib/src/models/user.dart
@@ -3,11 +3,11 @@ import 'package:equatable/equatable.dart';
 /// {@template user}
 /// User model
 ///
-/// [User.empty] represents an unauthenticated user.
+/// [AuthInfo.empty] represents an unauthenticated user.
 /// {@endtemplate}
-class User extends Equatable {
+class AuthInfo extends Equatable {
   /// {@macro user}
-  const User({
+  const AuthInfo({
     required this.id,
     this.email,
     this.name,
@@ -27,13 +27,13 @@ class User extends Equatable {
   final String? photo;
 
   /// Empty user which represents an unauthenticated user.
-  static const empty = User(id: '');
+  static const empty = AuthInfo(id: '');
 
   /// Convenience getter to determine whether the current user is empty.
-  bool get isEmpty => this == User.empty;
+  bool get isEmpty => this == AuthInfo.empty;
 
   /// Convenience getter to determine whether the current user is not empty.
-  bool get isNotEmpty => this != User.empty;
+  bool get isNotEmpty => this != AuthInfo.empty;
 
   @override
   List<Object?> get props => [email, id, name, photo];

--- a/packages/authentication_repository/test/authentication_repository_test.dart
+++ b/packages/authentication_repository/test/authentication_repository_test.dart
@@ -76,7 +76,7 @@ void main() {
 
   const email = 'test@gmail.com';
   const password = 't0ps3cret42';
-  const user = User(
+  const user = AuthInfo(
     id: _mockFirebaseUserUid,
     email: _mockFirebaseUserEmail,
   );
@@ -296,7 +296,7 @@ void main() {
             .thenAnswer((_) => Stream.value(null));
         await expectLater(
           authenticationRepository.user,
-          emitsInOrder(const <User>[User.empty]),
+          emitsInOrder(const <AuthInfo>[AuthInfo.empty]),
         );
       });
 
@@ -309,7 +309,7 @@ void main() {
             .thenAnswer((_) => Stream.value(firebaseUser));
         await expectLater(
           authenticationRepository.user,
-          emitsInOrder(const <User>[user]),
+          emitsInOrder(const <AuthInfo>[user]),
         );
         verify(
           () => cache.write(
@@ -327,7 +327,7 @@ void main() {
         ).thenReturn(null);
         expect(
           authenticationRepository.currentUser,
-          equals(User.empty),
+          equals(AuthInfo.empty),
         );
       });
 

--- a/packages/authentication_repository/test/models/user_test.dart
+++ b/packages/authentication_repository/test/models/user_test.dart
@@ -9,26 +9,26 @@ void main() {
 
     test('uses value equality', () {
       expect(
-        User(email: email, id: id),
-        equals(User(email: email, id: id)),
+        AuthInfo(email: email, id: id),
+        equals(AuthInfo(email: email, id: id)),
       );
     });
 
     test('isEmpty returns true for empty user', () {
-      expect(User.empty.isEmpty, isTrue);
+      expect(AuthInfo.empty.isEmpty, isTrue);
     });
 
     test('isEmpty returns false for non-empty user', () {
-      final user = User(email: email, id: id);
+      final user = AuthInfo(email: email, id: id);
       expect(user.isEmpty, isFalse);
     });
 
     test('isNotEmpty returns false for empty user', () {
-      expect(User.empty.isNotEmpty, isFalse);
+      expect(AuthInfo.empty.isNotEmpty, isFalse);
     });
 
     test('isNotEmpty returns true for non-empty user', () {
-      final user = User(email: email, id: id);
+      final user = AuthInfo(email: email, id: id);
       expect(user.isNotEmpty, isTrue);
     });
   });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,13 +218,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.1"
-  dio:
-    dependency: transitive
-    description:
-      name: dio
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.6"
   email_validator:
     dependency: transitive
     description:
@@ -743,13 +736,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
-  retrofit:
-    dependency: transitive
-    description:
-      name: retrofit
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1+1"
   rxdart:
     dependency: transitive
     description:


### PR DESCRIPTION
Authrepository에 token을 가져올 수 있도록 변경.
여기서 auth repository의 id token은 알아서 refresh도 진행해줌.

Signed-off-by: Hyukjoong Kim <wangmir@gmail.com>