### PR TITLE
Logout implementation & Refresh support.

### DIFF
--- a/lib/user_profile/view/user_profile_form.dart
+++ b/lib/user_profile/view/user_profile_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ming_api/ming_api.dart';
 
 import '../user_profile.dart';
@@ -61,23 +62,37 @@ class UserProfileForm extends StatelessWidget {
                 ),
               ],
             ),
+            const Divider(),
             state is UserProfileEditing
-                ? Row(
+                ? Column(
                     children: [
-                      ElevatedButton(
-                        onPressed: () => context
-                            .read<UserProfileCubit>()
-                            .updateUserProfile(state.user),
-                        child: const Text("Update"),
+                      Row(
+                        children: [
+                          ElevatedButton(
+                            onPressed: () => context
+                                .read<UserProfileCubit>()
+                                .updateUserProfile(state.user),
+                            child: const Text("Update"),
+                          ),
+                          ElevatedButton(
+                            onPressed: () => context
+                                .read<UserProfileCubit>()
+                                .cancelEditing(),
+                            child: const Text("Cancel"),
+                          ),
+                        ],
                       ),
-                      ElevatedButton(
-                        onPressed: () =>
-                            context.read<UserProfileCubit>().cancelEditing(),
-                        child: const Text("Cancel"),
-                      ),
+                      const Divider(),
                     ],
                   )
                 : Container(),
+            Row(
+              children: [
+                ElevatedButton(
+                    onPressed: () => context.go("/login"),
+                    child: const Text("Logout")),
+              ],
+            ),
           ],
         ),
       );

--- a/lib/user_profile/view/user_profile_page.dart
+++ b/lib/user_profile/view/user_profile_page.dart
@@ -19,11 +19,14 @@ class UserProfilePage extends StatelessWidget {
       body: BlocBuilder<UserProfileCubit, UserProfileState>(
         builder: (context, state) {
           if (state is UserProfileError) {
+            context.loaderOverlay.hide();
             return ErrorPage(message: state.message);
           }
 
           if (state is UserProfileInitial) {
             context.read<UserProfileCubit>().getUserProfile();
+            context.loaderOverlay.show();
+            return UserProfileForm(state.user);
           }
 
           if (state is UserProfileUpdating) {

--- a/packages/authentication_repository/lib/src/authentication_repository.dart
+++ b/packages/authentication_repository/lib/src/authentication_repository.dart
@@ -202,6 +202,8 @@ class AuthenticationRepository {
   /// get id token for the user, if token is expired, then refresh it.
   /// Throws a [UserIsNotLoggedInFailure] if user is not logged in before.
   Future<String> get idToken async {
+    // we need to wait fir userChanges to ensure login status at refresh.
+    await _firebaseAuth.userChanges().first;
     if (_firebaseAuth.currentUser == null) throw UserIsNotLoggedInFailure();
 
     return _firebaseAuth.currentUser!.getIdToken();


### PR DESCRIPTION
1. Logout button을 profile에 만듦.
2. Refresh 시에도 auth가 정상동작하도록 함 (refresh 시에 async하게 user status change가 되는 걸 기다림)

Signed-off-by: Hyukjoong Kim <wangmir@gmail.com>