### PR TITLE
Refine menu bar.

### DIFF
--- a/lib/common/routes.dart
+++ b/lib/common/routes.dart
@@ -55,10 +55,8 @@ enum MingRoutingAddress {
 }
 
 enum MingNavigator {
-  home(MingRoutingAddress.home, "Home", Icon(Icons.home_filled)),
-  shelters(MingRoutingAddress.shelters, "Shelters", Icon(Icons.night_shelter)),
-  pets(MingRoutingAddress.pets, "Pets", Icon(Icons.pets)),
-  myProfile(MingRoutingAddress.myProfile, "Profile", Icon(Icons.person)),
+  home(MingRoutingAddress.home, "홈", Icon(Icons.home_filled)),
+  shelters(MingRoutingAddress.shelters, "보호소", Icon(Icons.night_shelter)),
   ;
 
   final MingRoutingAddress routes;
@@ -130,12 +128,12 @@ final router = GoRouter(
       pageBuilder: (context, state) {
         context.read<UserProfileCubit>().initialize();
 
-        return MaterialPage<void>(
+        return const MaterialPage<void>(
           key: _pageKey,
           child: RootLayout(
             key: _scaffoldKey,
-            currentIndex: MingNavigator.myProfile.offset(),
-            child: const UserProfilePage(),
+            currentIndex: -1,
+            child: UserProfilePage(),
           ),
         );
       },

--- a/lib/common/ui/menu_bar.dart
+++ b/lib/common/ui/menu_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ming/auth/bloc/auth_bloc.dart';
 import 'package:ming/common/routes.dart';
 import 'package:ming/generated/l10n.dart';
 
@@ -32,30 +34,24 @@ class MenuBar extends StatelessWidget implements PreferredSizeWidget {
                   ),
                 ),
               ),
-              Flexible(
-                flex: 8,
-                child: Container(
-                  alignment: Alignment.centerRight,
-                  child: Wrap(
-                    children: destinations
-                        .map(
-                          (e) => MenuItem(
-                            e,
-                            destinations.indexOf(e) == selectedIndex,
-                          ),
-                        )
-                        .toList(),
-                  ),
+              const Spacer(),
+              Container(
+                alignment: Alignment.centerRight,
+                child: Wrap(
+                  children: destinations
+                      .map(
+                        (e) => MenuItem(
+                          e,
+                          destinations.indexOf(e) == selectedIndex,
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
-              Flexible(
-                flex: 1,
-                child: IconButton(
-                  onPressed: () => context.go(MingRoutingAddress.login.address),
-                  icon: const Icon(Icons.person),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-                ),
+              const Spacer(),
+              const Padding(
+                padding: EdgeInsets.only(right: 15),
+                child: UserMenuItem(),
               ),
             ],
           ),
@@ -91,6 +87,29 @@ class MenuItem extends StatelessWidget {
         horizontal: 16,
         vertical: 16,
       )),
+    );
+  }
+}
+
+class UserMenuItem extends StatelessWidget {
+  const UserMenuItem({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthBloc, AuthState>(
+      builder: (context, state) {
+        if (state is Authenticated) {
+          return IconButton(
+            onPressed: () => context.go(MingRoutingAddress.myProfile.address),
+            icon: const Icon(Icons.person),
+          );
+        }
+
+        return TextButton(
+          onPressed: () => context.go(MingRoutingAddress.login.address),
+          child: Text(S.of(context).loginButtonText),
+        );
+      },
     );
   }
 }

--- a/lib/generated/intl/messages_ko_KR.dart
+++ b/lib/generated/intl/messages_ko_KR.dart
@@ -28,6 +28,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "initialStateTryClickRefreshButton":
             MessageLookupByLibrary.simpleMessage(
                 "Initial state, try click refresh button."),
+        "loginButtonText": MessageLookupByLibrary.simpleMessage("로그인 및 회원가입"),
         "loginFailedMessage":
             MessageLookupByLibrary.simpleMessage("로그인에 실패하였습니다."),
         "loginSuccessMessage":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -209,6 +209,16 @@ class S {
       args: [],
     );
   }
+
+  /// `로그인 및 회원가입`
+  String get loginButtonText {
+    return Intl.message(
+      '로그인 및 회원가입',
+      name: 'loginButtonText',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_ko_KR.arb
+++ b/lib/l10n/intl_ko_KR.arb
@@ -14,5 +14,6 @@
   "shelterSinglePageTitle": "쉼터 페이지",
   "loginFailedMessage": "로그인에 실패하였습니다.",
   "loginSuccessMessage": "로그인에 성공하였습니다.",
-  "regionString": "봉사지역"
+  "regionString": "봉사지역",
+  "loginButtonText": "로그인 및 회원가입"
 }

--- a/lib/user_profile/view/user_profile_form.dart
+++ b/lib/user_profile/view/user_profile_form.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ming/auth/bloc/auth_bloc.dart';
+import 'package:ming/common/routes.dart';
 import 'package:ming_api/ming_api.dart';
 
 import '../user_profile.dart';
@@ -89,7 +91,10 @@ class UserProfileForm extends StatelessWidget {
             Row(
               children: [
                 ElevatedButton(
-                    onPressed: () => context.go("/login"),
+                    onPressed: () {
+                      context.read<AuthBloc>().add(LogOut());
+                      context.go(MingRoutingAddress.login.address);
+                    },
                     child: const Text("Logout")),
                 ElevatedButton(
                     onPressed: () => context.go("/shelters?auth=true"),

--- a/packages/authentication_repository/pubspec.lock
+++ b/packages/authentication_repository/pubspec.lock
@@ -554,5 +554,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.8.0"


### PR DESCRIPTION
Menu bar에서 홈, 보호소만 보이게 하고, 사용자 프로필 버튼을 로그인 시와 로그인 하지 않았을 때를 구분해서 변경할 수 있도록 지원.

Signed-off-by: Hyukjoong Kim <wangmir@gmail.com>