### PR TITLE
Remove url Path strategy from main.dart.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,6 @@ Future<void> main() async {
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 
     Log.i("Hello Ming App!");
-    usePathUrlStrategy();
     runApp(const Ming());
   }, (error, stack) {
     if (!kIsWeb) {


### PR DESCRIPTION
check https://levelup.gitconnected.com/how-to-remove-hash-symbol-from-url-with-flutter-web-d917137b8041 for detail.

url path를 사용할 경우에 url로 direct access를 하면 404 not found가 나오는 문제가 있습니다. 이를 hash로 대체해야만, 먼저 main.dart로 진입해서 거기서 routing이 가능하기 떄문에 hash를 쓰는 방식으로 다시 변경합니다.

Signed-off-by: Kim, Hyukjoong <wangmir@gmail.com>