### PR TITLE
context.push를 사용했을 때 album view가 racing하는 문제 수정.

### DIFF
--- a/lib/common/ui/pet_card_content.dart
+++ b/lib/common/ui/pet_card_content.dart
@@ -20,7 +20,7 @@ class PetCardContent extends StatelessWidget {
     final descriptionStyle = theme.textTheme.subtitle1!;
     return MingImageCard(
       onTap: () {
-        context.push(MingRoutingAddress.pets.address + "/${pet.id}");
+        context.go(MingRoutingAddress.pets.address + "/${pet.id}");
       },
       image: NetworkImage(pet.imageUrl),
       child: Padding(

--- a/lib/pet_profile/view/pet_profile_form.dart
+++ b/lib/pet_profile/view/pet_profile_form.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ming/album/view/album_view.dart';
 import 'package:ming/common/adaptive_builder.dart';
 import 'package:ming/common/ming_icons.dart';
+import 'package:ming/common/routes.dart';
 import 'package:ming/common/ui/contact_to_shelter_card.dart';
 import 'package:ming/common/ui/shelter_card_content.dart';
 import 'package:ming/pet_profile/model/pet_profile.dart';
@@ -96,7 +97,8 @@ class PetProfileMobileForm extends StatelessWidget {
             child: IconButton(
               iconSize: 24,
               onPressed: () {
-                context.pop();
+                context
+                    .go(MingRoutingAddress.shelters.address + "/${shelter.id}");
               },
               icon: Icon(MingIcons.leftArrow),
             ),

--- a/lib/shelters/view/shelters_page.dart
+++ b/lib/shelters/view/shelters_page.dart
@@ -15,7 +15,6 @@ class SheltersPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // todo: change mock into real one.
       body: BlocBuilder<SheltersBloc, SheltersState>(
         builder: (context, state) {
           var info = SheltersInfo.empty();


### PR DESCRIPTION
context.go 대신 context.push로 접근할 경우 underlying page에 대해서도 bloc가 계속 동작하는 문제가 있음. push를 go로 변경하고, 뒤로가기를 실제 workflow에 맞춰서 수정.

Signed-off-by: Hyukjoong Kim <wangmir@gmail.com>